### PR TITLE
Add unit and sim tests: RNG, targeting, shop odds; board harness (#15)

### DIFF
--- a/Assets/Tests/EditMode/DeterministicRngTests.cs
+++ b/Assets/Tests/EditMode/DeterministicRngTests.cs
@@ -1,0 +1,53 @@
+using NUnit.Framework;
+using TestTFT.Scripts.Runtime.Systems.Core;
+
+public class DeterministicRngTests
+{
+    [Test]
+    public void SameSeed_YieldsSameSequence_PerStream()
+    {
+        DeterministicRng.SetSeed(42UL);
+        var a1 = DeterministicRng.NextInt(DeterministicRng.Stream.Loot, 0, 1000);
+        var a2 = DeterministicRng.NextInt(DeterministicRng.Stream.Loot, 0, 1000);
+        var af1 = DeterministicRng.NextFloat01(DeterministicRng.Stream.Loot);
+
+        DeterministicRng.SetSeed(42UL);
+        var b1 = DeterministicRng.NextInt(DeterministicRng.Stream.Loot, 0, 1000);
+        var b2 = DeterministicRng.NextInt(DeterministicRng.Stream.Loot, 0, 1000);
+        var bf1 = DeterministicRng.NextFloat01(DeterministicRng.Stream.Loot);
+
+        Assert.AreEqual(a1, b1);
+        Assert.AreEqual(a2, b2);
+        Assert.AreEqual(af1, bf1);
+    }
+
+    [Test]
+    public void DifferentStreams_AreIndependent()
+    {
+        DeterministicRng.SetSeed(123UL);
+        // Draw a few from Shop
+        var s1 = DeterministicRng.NextInt(DeterministicRng.Stream.Shop, 0, 10000);
+        var s2 = DeterministicRng.NextInt(DeterministicRng.Stream.Shop, 0, 10000);
+        // Draw from Targeting
+        DeterministicRng.SetSeed(123UL);
+        var t1 = DeterministicRng.NextInt(DeterministicRng.Stream.Targeting, 0, 10000);
+        var t2 = DeterministicRng.NextInt(DeterministicRng.Stream.Targeting, 0, 10000);
+
+        // With same seed, sequences within stream are equal, but across streams differ
+        Assert.AreNotEqual(s1, t1);
+        Assert.AreNotEqual(s2, t2);
+    }
+
+    [Test]
+    public void NextInt_RespectsBounds()
+    {
+        DeterministicRng.SetSeed(777UL);
+        for (int i = 0; i < 1000; i++)
+        {
+            var v = DeterministicRng.NextInt(DeterministicRng.Stream.Loot, 5, 9);
+            Assert.GreaterThanOrEqual(v, 5);
+            Assert.Less(v, 9);
+        }
+    }
+}
+

--- a/Assets/Tests/EditMode/ShopOddsTests.cs
+++ b/Assets/Tests/EditMode/ShopOddsTests.cs
@@ -1,0 +1,54 @@
+using NUnit.Framework;
+using TestTFT.Scripts.Runtime.Systems.Core;
+using TestTFT.Scripts.Runtime.Systems.Gameplay;
+
+public class ShopOddsTests
+{
+    [Test]
+    public void Locked_Shop_DoesNotChange_OnReroll()
+    {
+        DeterministicRng.SetSeed(999UL);
+        var shop = new ShopSystem();
+        shop.RerollForLevel(3);
+        var before = (ShopSystem.Offer[])shop.Current.Clone();
+
+        shop.ToggleLock();
+        shop.RerollForLevel(3);
+
+        for (int i = 0; i < before.Length; i++)
+        {
+            Assert.AreEqual(before[i].Cost, shop.Current[i].Cost);
+            Assert.AreEqual(before[i].Name, shop.Current[i].Name);
+        }
+    }
+
+    [Test]
+    public void CostDistribution_MatchesOdds_WithinTolerance_Level5()
+    {
+        DeterministicRng.SetSeed(12345UL);
+        var shop = new ShopSystem();
+
+        int nSamples = 2000; // 2000 * 5 = 10k offers
+        int c1 = 0, c2 = 0, c3 = 0;
+        for (int i = 0; i < nSamples; i++)
+        {
+            shop.RerollForLevel(5);
+            for (int k = 0; k < 5; k++)
+            {
+                var cost = shop.Current[k].Cost;
+                if (cost == 1) c1++; else if (cost == 2) c2++; else if (cost == 3) c3++;
+            }
+        }
+
+        float total = c1 + c2 + c3;
+        float p1 = c1 / total;
+        float p2 = c2 / total;
+        float p3 = c3 / total;
+
+        // From odds table at level 5: {0.45, 0.40, 0.15}
+        Assert.That(p1, Is.InRange(0.40f, 0.50f));
+        Assert.That(p2, Is.InRange(0.35f, 0.45f));
+        Assert.That(p3, Is.InRange(0.12f, 0.18f));
+    }
+}
+

--- a/Assets/Tests/EditMode/TargetingTests.cs
+++ b/Assets/Tests/EditMode/TargetingTests.cs
@@ -1,0 +1,104 @@
+using NUnit.Framework;
+using UnityEngine;
+using TestTFT.Scripts.Runtime.Combat;
+using TestTFT.Scripts.Runtime.Combat.Unit;
+using TestTFT.Scripts.Runtime.Systems.Simulation;
+
+public class TargetingTests
+{
+    private GameObject SpawnUnit(string name, Vector3 pos)
+    {
+        var go = new GameObject(name);
+        go.transform.position = pos;
+        go.AddComponent<HealthComponent>();
+        go.AddComponent<ManaComponent>();
+        go.AddComponent<TestTFT.Scripts.Runtime.Combat.Effects.EffectsController>();
+        go.AddComponent<TestTFT.Scripts.Runtime.Combat.Ability.AbilityExecutor>();
+        go.AddComponent<UnitBehaviour>();
+        return go;
+    }
+
+    [SetUp]
+    public void SetUp()
+    {
+        SimulationSystem.ClearUnits();
+    }
+
+    [TearDown]
+    public void TearDown()
+    {
+        SimulationSystem.ClearUnits();
+    }
+
+    [Test]
+    public void AutoAcquires_Nearest_Living_Target()
+    {
+        var simGO = new GameObject("Sim");
+        var sim = simGO.AddComponent<SimulationSystem>();
+
+        var seeker = SpawnUnit("Seeker", Vector3.zero);
+        var far = SpawnUnit("Far", new Vector3(5, 0, 0));
+        var near = SpawnUnit("Near", new Vector3(1, 0, 0));
+
+        // No explicit target; simulate 1 tick
+        sim.TickOnce();
+        Assert.AreSame(near, seeker.GetComponent<UnitBehaviour>().CurrentTarget);
+
+        Object.DestroyImmediate(seeker);
+        Object.DestroyImmediate(far);
+        Object.DestroyImmediate(near);
+        Object.DestroyImmediate(simGO);
+    }
+
+    [Test]
+    public void Retargets_When_Target_Dies()
+    {
+        var simGO = new GameObject("Sim");
+        var sim = simGO.AddComponent<SimulationSystem>();
+
+        var seeker = SpawnUnit("Seeker", Vector3.zero);
+        var near = SpawnUnit("Near", new Vector3(1, 0, 0));
+        var far = SpawnUnit("Far", new Vector3(2, 0, 0));
+
+        sim.TickOnce();
+        var ub = seeker.GetComponent<UnitBehaviour>();
+        Assert.AreSame(near, ub.CurrentTarget);
+
+        // Kill current target
+        near.GetComponent<HealthComponent>().ApplyDamage(1000f, new DamageContext(seeker, near, false));
+        sim.TickOnce();
+        Assert.AreSame(far, ub.CurrentTarget);
+
+        Object.DestroyImmediate(seeker);
+        Object.DestroyImmediate(near);
+        Object.DestroyImmediate(far);
+        Object.DestroyImmediate(simGO);
+    }
+
+    [Test]
+    public void TieBreakers_AreStable_ByInstanceId()
+    {
+        var simGO = new GameObject("Sim");
+        var sim = simGO.AddComponent<SimulationSystem>();
+
+        var seeker = SpawnUnit("Seeker", Vector3.zero);
+        // Create two equidistant targets; the one created first should have a smaller instance ID typically
+        var a = SpawnUnit("A", new Vector3(1, 0, 0));
+        var b = SpawnUnit("B", new Vector3(-1, 0, 0));
+
+        sim.TickOnce();
+        var ub = seeker.GetComponent<UnitBehaviour>();
+        Assert.IsNotNull(ub.CurrentTarget);
+
+        var chosen = ub.CurrentTarget;
+        // Run more ticks to ensure stability
+        for (int i = 0; i < 5; i++) sim.TickOnce();
+        Assert.AreSame(chosen, ub.CurrentTarget);
+
+        Object.DestroyImmediate(seeker);
+        Object.DestroyImmediate(a);
+        Object.DestroyImmediate(b);
+        Object.DestroyImmediate(simGO);
+    }
+}
+

--- a/Assets/Tests/EditMode/TestBoardHarness.cs
+++ b/Assets/Tests/EditMode/TestBoardHarness.cs
@@ -1,0 +1,69 @@
+using System.Collections.Generic;
+using NUnit.Framework;
+using UnityEngine;
+using TestTFT.Scripts.Runtime.Combat;
+using TestTFT.Scripts.Runtime.Combat.Unit;
+using TestTFT.Scripts.Runtime.Systems.Simulation;
+
+public static class TestBoardHarness
+{
+    public sealed class Board
+    {
+        public SimulationSystem sim;
+        public List<GameObject> units = new List<GameObject>();
+    }
+
+    public static Board SpawnBoard(params Vector3[] positions)
+    {
+        var b = new Board();
+        var simGO = new GameObject("Sim");
+        b.sim = simGO.AddComponent<SimulationSystem>();
+
+        foreach (var pos in positions)
+        {
+            var u = new GameObject("Unit");
+            u.transform.position = pos;
+            u.AddComponent<HealthComponent>();
+            u.AddComponent<ManaComponent>();
+            u.AddComponent<TestTFT.Scripts.Runtime.Combat.Effects.EffectsController>();
+            u.AddComponent<TestTFT.Scripts.Runtime.Combat.Ability.AbilityExecutor>();
+            u.AddComponent<UnitBehaviour>();
+            b.units.Add(u);
+        }
+
+        return b;
+    }
+
+    public static void RunTicks(Board b, int steps)
+    {
+        for (int i = 0; i < steps; i++) b.sim.TickOnce();
+    }
+
+    public static void Destroy(Board b)
+    {
+        foreach (var u in b.units) Object.DestroyImmediate(u);
+        if (b.sim != null) Object.DestroyImmediate(b.sim.gameObject);
+        SimulationSystem.ClearUnits();
+    }
+}
+
+public class BoardHarnessSmokeTest
+{
+    [Test]
+    public void TwoUnits_MoveAndFight()
+    {
+        var board = TestBoardHarness.SpawnBoard(new Vector3(-2, 0, 0), new Vector3(2, 0, 0));
+        // Run for a few seconds (10Hz)
+        TestBoardHarness.RunTicks(board, 100);
+
+        var a = board.units[0].GetComponent<HealthComponent>().CurrentHealth;
+        var b = board.units[1].GetComponent<HealthComponent>().CurrentHealth;
+
+        // Expect some damage exchanged but not necessarily dead
+        Assert.Less(a, 100f);
+        Assert.Less(b, 100f);
+
+        TestBoardHarness.Destroy(board);
+    }
+}
+

--- a/Assets/_Project/Scripts/Runtime/Combat/Ability/AbilityExecutor.cs
+++ b/Assets/_Project/Scripts/Runtime/Combat/Ability/AbilityExecutor.cs
@@ -33,13 +33,6 @@ namespace TestTFT.Scripts.Runtime.Combat.Ability
 
             // Global timing
             CombatTime.EnsureStarted();
-            // Resolve crit
-            bool isCrit = TestTFT.Scripts.Runtime.Systems.Core.DeterministicRng.NextFloat01(TestTFT.Scripts.Runtime.Systems.Core.DeterministicRng.Stream.Targeting) < spell.critChance;
-            float outgoingMult = effects != null ? effects.GetOutgoingDamageMultiplier() : 1f;
-            float damage = Mathf.Max(0f, spell.baseDamage) * outgoingMult;
-            if (isCrit)
-                damage *= Mathf.Max(1f, spell.critMultiplier);
-
             bool isDodged = false;
             bool isCrit = false;
             float dealt = 0f;
@@ -56,8 +49,9 @@ namespace TestTFT.Scripts.Runtime.Combat.Ability
                 }
                 else
                 {
-                    // Crit resolves after dodge
-                    isCrit = UnityEngine.Random.value < spell.critChance;
+                    // Crit resolves after dodge using deterministic RNG stream
+                    isCrit = TestTFT.Scripts.Runtime.Systems.Core.DeterministicRng
+                        .NextFloat01(TestTFT.Scripts.Runtime.Systems.Core.DeterministicRng.Stream.Targeting) < spell.critChance;
 
                     float outgoingMult = effects != null ? effects.GetOutgoingDamageMultiplier() : 1f;
                     // Apply global overtime multiplier

--- a/Assets/_Project/Scripts/Runtime/Combat/CombatStats.cs
+++ b/Assets/_Project/Scripts/Runtime/Combat/CombatStats.cs
@@ -37,8 +37,9 @@ namespace TestTFT.Scripts.Runtime.Combat
         {
             if (dodgeChance <= 0f) return false;
             if (dodgeChance >= 1f) return true;
-            return Random.value < dodgeChance;
+            // Use deterministic RNG stream for combat-targeting related rolls
+            return TestTFT.Scripts.Runtime.Systems.Core.DeterministicRng
+                .NextFloat01(TestTFT.Scripts.Runtime.Systems.Core.DeterministicRng.Stream.Targeting) < dodgeChance;
         }
     }
 }
-


### PR DESCRIPTION
This PR addresses #15 by adding comprehensive unit and simulation tests and a lightweight board harness.

Highlights
- RNG: DeterministicRng tests for seed reproducibility, stream independence, and bounds
- Combat: Targeting tests (nearest acquisition, retarget on death, deterministic tie-breakers)
- Shop: Odds sampling test at L5 and locked behavior test
- Harness: TestBoardHarness utility to spawn boards and tick the sim
- Determinism: AbilityExecutor & CombatStats now use DeterministicRng for crit/dodge

Acceptance: All tests run as EditMode tests and are designed to pass in editor/CI.

Notes
- Tests avoid long runtimes; sampling kept moderate (10k offers) with tolerances
- No gameplay balance changes; only deterministic RNG usage and tests added
