### PR TITLE
#11 Round system MVP: stages, timers, PvE and damage

### DIFF
--- a/Assets/_Project/Scripts/Runtime/Systems/Bootstrap/UIBootstrap.cs
+++ b/Assets/_Project/Scripts/Runtime/Systems/Bootstrap/UIBootstrap.cs
@@ -91,6 +91,12 @@ namespace TestTFT.Scripts.Runtime.Systems.Bootstrap
                     _health.ApplyDamage(damage);
                 }
             }
+            else
+            {
+                // PvE loot orbs MVP: grant 1-2 gold using deterministic RNG
+                int loot = TestTFT.Scripts.Runtime.Systems.Core.DeterministicRng.NextInt(TestTFT.Scripts.Runtime.Systems.Core.DeterministicRng.Stream.Loot, 1, 3);
+                _economy.AddGold(loot);
+            }
         }
 
         private static void EnsureEventSystem()


### PR DESCRIPTION
Implements the MVP round system per meta/game-design.md.\n\nChanges:\n- Consistent end-of-round resolution after Combat (PvE/PvP).\n- Stage/round tracking; Shop/Combat/Carousel timers matching MVP.\n- PvE waves grant deterministic loot orbs (1–2 gold).\n- PvP damage = StageBase + SurvivingStarDamage (MVP proxy).\n- Proper OnRoundStarted/OnRoundResolved events enabling end-of-round updates.\n\nAcceptance: End-of-round updates and damage resolve are implemented.\n\nNotes:\n- SurvivingStarDamage uses a deterministic placeholder (0–3) until unit-based survival tracking is integrated.\n- Carousel is every 3rd round as an MVP cadence.